### PR TITLE
Fix CVE-2026-24734 and CVE-2026-0994

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.10'
+    id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
     id 'org.owasp.dependencycheck' version '12.1.3'
@@ -30,8 +30,8 @@ dependencies {
 
     implementation 'org.apache.jena:apache-jena-libs:4.10.0'
     constraints {
-        implementation('com.google.protobuf:protobuf-java:3.25.5') {
-            because 'CVE-2024-7254 — DoS via StackOverflow in recursive unknown fields parsing'
+        implementation('com.google.protobuf:protobuf-java:3.25.8') {
+            because 'CVE-2024-7254, CVE-2026-0994 — DoS via StackOverflow in recursive unknown fields parsing'
         }
         implementation('org.apache.commons:commons-lang3:3.18.0') {
             because 'CVE-2025-48924 — StackOverflow in ClassUtils.getClass on long inputs'


### PR DESCRIPTION
## Summary
- Spring Boot 3.5.10 → 3.5.13 (fixes Tomcat CVE-2026-24734)
- protobuf-java 3.25.5 → 3.25.8 (fixes CVE-2026-0994)

These CVEs cause OWASP dependency-check to fail, blocking Docker image publishing since PR #92 merge.