### PR TITLE
Fix OWASP failures: commons-lang3 and protobuf-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ group = 'it.gov.innovazione'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '21'
 
+ext['commons-lang3.version'] = '3.20.0'
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -32,9 +34,6 @@ dependencies {
     constraints {
         implementation('com.google.protobuf:protobuf-java:3.25.8') {
             because 'CVE-2024-7254, CVE-2026-0994 — DoS via StackOverflow in recursive unknown fields parsing'
-        }
-        implementation('org.apache.commons:commons-lang3:3.18.0') {
-            because 'CVE-2025-48924 — StackOverflow in ClassUtils.getClass on long inputs'
         }
     }
 

--- a/config/dependency-check/dependency-check-known-issues.xml
+++ b/config/dependency-check/dependency-check-known-issues.xml
@@ -20,6 +20,14 @@
         <cve>CVE-2025-68161</cve>
     </suppress>
 
+    <!-- protobuf-java 3.25.x DoS via crafted messages.
+         Fix only available in 4.x line; Jena 4.10.0 requires 3.x.
+         LodView does not process untrusted protobuf input (only SPARQL/RDF). -->
+    <suppress>
+        <notes><![CDATA[protobuf-java DoS — not exploitable: LodView does not process untrusted protobuf messages]]></notes>
+        <cve>CVE-2026-0994</cve>
+    </suppress>
+
     <!-- jQuery 1.12.4 bundled in static resources. Upgrade to 3.x deferred to future session
          (requires testing all JSP templates and JavaScript interactions). -->
     <suppress>


### PR DESCRIPTION
## Summary
- Override commons-lang3 to 3.20.0 via ext property (Spring Boot BOM was downgrading the constraint to 3.17.0)
- Suppress CVE-2026-0994 for protobuf-java 3.25.x (fix only in 4.x, not exploitable: LodView does not process untrusted protobuf input)

Follows up on #95 (Spring Boot 3.5.13 + protobuf-java 3.25.8). Build and OWASP verified locally.